### PR TITLE
Serve frontend from backend

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -20,28 +20,13 @@ connection.once('open', () => {
     console.log('Connection to MongoDB established successfully')
 })
 
-//new stuff from tutorial on how to connect backend and frontend
-//start
-if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging') {
-    // Add production middleware such as redirecting to https
-
-    // Express will serve up production assets i.e. main.js
-    app.use(express.static(__dirname + '../build'));
-    // If Express doesn't recognize route serve index.html
-    const path = require('path');
-    app.get('*', (req, res) => {
-        res.sendFile(
-            path.resolve(__dirname, '../', '/..build', 'index.html')
-        );
-    });
-}
-// end
-
 // *** REQUIRE ROUTE FILES AND USE THEM ***
 const vehiclesRouter = require('./routes/vehicles')
 app.use('/vehicles', vehiclesRouter)
 
-app.use(express.static('frontEndBuild'))
+if (process.env.NODE_ENV === 'production') {
+    app.use(express.static('frontEndBuild'));
+}
 
 app.listen(port, () => {
     console.log(`Server is running on port ${port}`) // tells server to listen on a certain port

--- a/backend/server.js
+++ b/backend/server.js
@@ -41,6 +41,8 @@ if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'staging')
 const vehiclesRouter = require('./routes/vehicles')
 app.use('/vehicles', vehiclesRouter)
 
+app.use(express.static('frontEndBuild'))
+
 app.listen(port, () => {
     console.log(`Server is running on port ${port}`) // tells server to listen on a certain port
 })

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "scripts": {
     "predeploy": "npm run build",
-    "start": "react-scripts start",
+    "startDev": "react-scripts start",
+    "start": "cd backend && npm run start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "predeploy": "npm run build",
     "startDev": "react-scripts start",
     "start": "cd backend && npm run start",
-    "build": "react-scripts build",
+    "build": "react-scripts build && rm -R backend/frontEndBuild && cp -R build backend/frontEndBuild",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/src/components/url.js
+++ b/src/components/url.js
@@ -1,4 +1,3 @@
 
-const url = process.env.NODE_ENV='production' ? window.location.href : 'http://localhost:5000'
-
+const url = process.env.NODE_ENV==='production' ? window.location.href : 'http://localhost:5000/'
 export default url;

--- a/src/components/url.js
+++ b/src/components/url.js
@@ -1,0 +1,4 @@
+
+const url = process.env.NODE_ENV='production' ? window.location.href : 'http://localhost:5000'
+
+export default url;

--- a/src/components/vehicle-list.component.js
+++ b/src/components/vehicle-list.component.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import axios from 'axios'
-import url from 'url';
+import url from './url';
 
 require('dotenv').config()
 
@@ -32,7 +32,7 @@ export default class VehicleList extends React.Component {
     }
     
     componentDidMount() { // this method adds a list of vehicles from the server (MongoDB) to the state as array
-        axios.get(`${url}/vehicles`)
+        axios.get(`${url}vehicles`)
         .then(res => {
             this.setState({
                 vehicles: res.data

--- a/src/components/vehicle-list.component.js
+++ b/src/components/vehicle-list.component.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import axios from 'axios'
+import url from 'url';
 
 require('dotenv').config()
 
@@ -31,7 +32,7 @@ export default class VehicleList extends React.Component {
     }
     
     componentDidMount() { // this method adds a list of vehicles from the server (MongoDB) to the state as array
-        axios.get(`http://localhost:5000/vehicles`)
+        axios.get(`${url}/vehicles`)
         .then(res => {
             this.setState({
                 vehicles: res.data


### PR DESCRIPTION
Should now be able to run

In DEV 
- same as before, but use 'startDev' rather then 'start' for front end

In PROD
- in root directory, npm run build, npm run start (will start back that will also server front end)

TODO:
* change all get requests to use URL
* .gitignore build folders, .env and node modules folders